### PR TITLE
Update regionalgruppen.txt

### DIFF
--- a/regionalgruppen.txt
+++ b/regionalgruppen.txt
@@ -14,7 +14,7 @@ Dortmund
 Dresden
 Emden / Leer
 Erlangen
-Frankfurt
+Frankfurt am Main
 Freiburg
 Gießen
 Greifswald


### PR DESCRIPTION
Wir wollen gerne das "am Main" einfügen, um den Platz für Frankfurt an der Oder auf zu machen. Liebe Grüße