### PR TITLE
S4F Hessen

### DIFF
--- a/regionalgruppen.txt
+++ b/regionalgruppen.txt
@@ -23,6 +23,7 @@ Halle
 Hamburg
 Hannover
 Heidelberg
+Hessen
 Innsbruck
 Kaiserslautern
 Karlsruhe


### PR DESCRIPTION
Hinzufügen: Regionallogo für den Zusammenschluss der RGs in Hessen