### PR TITLE
Füge RG-Verband RLP hinzu

### DIFF
--- a/regionalgruppen.txt
+++ b/regionalgruppen.txt
@@ -60,6 +60,7 @@ Ravensburg
 Regensburg
 Reutlingen
 Rhein / Ruhr
+Rheinland-Pfalz
 Rosenheim
 Rostock
 Saarland


### PR DESCRIPTION
Rheinland-Pfalz möchte sich organisieren und gemeinsam auftreten.